### PR TITLE
Add contribution ladder

### DIFF
--- a/docs/contribution-ladder.md
+++ b/docs/contribution-ladder.md
@@ -1,0 +1,105 @@
+# Contribution Ladder
+
+Our ladder defines the roles and responsibilities on in the repositories in this
+project and how to participate with the goal of moving from a user to a
+maintainer. You will need to gain people's trust, demonstrate your competence
+and understanding, and meet the requirements of the role.
+
+* [Community Members](#community-members)
+* [Contributor](#contributor)
+* [How to become a contributor](#how-to-become-a-contributor)
+* [Maintainer](#maintainer)
+* [How to become a maintainer](#how-to-become-a-maintainer)
+* [Admin](#admin)
+* [How to become an admin](#admin)
+
+
+## Community Members
+
+Everyone is a community member! 😄 You've read this far so you are already ahead. 💯
+
+Here are some ideas for how you can be more involved and participate in the community:
+
+* Comment on an issue that you’re interested in.
+* Submit a pull request to fix an issue.
+* Report a bug.
+* Share a bundle that you made and how it went.
+* Come chat with us in [Slack][slack].
+
+They must follow our [Code of Conduct][conduct].
+
+## Contributor
+
+Contributors have the following capabilities:
+
+* Have issues and pull requests assigned to them
+* Apply labels, milestones and projects
+* [Mark issues as duplicates](https://help.github.com/en/articles/about-duplicate-issues-and-pull-requests) 
+* Close, reopen, and assign issues and pull requests
+
+They must agree to and follow this Contributing Guide.
+
+### How to become a contributor
+
+To become a contributor, the maintainers of the project would like to see you:
+
+* Comment on issues with your experiences and opinions.
+* Add your comments and reviews on pull requests.
+* Contribute pull requests.
+* Open issues with bugs, experience reports, and questions.
+
+Contributors and maintainers will do their best to watch for community members
+who may make good contributors. But don’t be shy, if you feel that this is you,
+please reach out to one or more of the contributors or maintainers.
+
+[contributors]: https://github.com/orgs/cnabio/teams/cnab-contributors
+
+## Maintainer
+
+Maintainers are members with extra capabilities: 
+
+* Be a code owner and have reviews automatically requested.
+* Review pull requests.
+* Merge pull requests.
+
+Maintainers also have additional responsibilities beyond just merging code:
+
+* Help foster a safe and welcoming environment for all project participants. 
+  This will include understanding and enforcing our [Code of Conduct][conduct].
+* Organize and promote pull request reviews, e.g. prompting community members, 
+  contributors, and other maintainers to review.
+* Triage issues, e.g. adding labels, promoting discussions, finalizing decisions.
+* Help organize our development meetings, e.g. schedule, organize and 
+  execute agenda.
+
+Each logical set of repositories has a separate [team](https://github.com/orgs/cnabio/teams)
+to manage its maintainers.
+
+### How to become a maintainer
+    
+To become a maintainer, we would like you to see you be an effective
+contributor, and show that you can do some of the things maintainers do.
+Maintainers will do their best to regularly discuss promoting contributors. But
+don’t be shy, if you feel that this is you, please reach out to one or more of
+the maintainers.
+    
+## Admin
+
+Admins are maintainers with extra responsibilities:
+
+* Create new mixin repositories
+* Manage porter-* repositories
+* Manage porter-* teams
+
+Each logical set of repositories has a separate [team](https://github.com/orgs/cnabio/teams)
+to manage its admins.
+
+### How to become an admin
+
+It isn't expected that all maintainers will need or want to move up to admin. If
+you are a maintainer, and find yourself often asking an admin to do certain
+tasks for you and you would like to help out with administrative tasks, please
+reach out to one or more of the admins.
+
+[conduct]: https://opensource.microsoft.com/codeofconduct/
+[slack]: https://cnab.io/community-meetings/#communications


### PR DESCRIPTION
This is a modified version of the contribution ladder from Porter.

https://github.com/deislabs/porter/blob/master/CONTRIBUTING.md#contribution-ladder

It applies to all the repositories in the CNAB project, for example duffle, cnab-go and cnab-spec. They can then link to these docs from their contributing guide to explain how to move up from a user to a maintainer.

🚨 It was written in anticipation of this repository moving to the new cnabio organization and references the teams in that org.