### PR TITLE
Add common documents

### DIFF
--- a/docs/shared/CONTRIBUTING.md
+++ b/docs/shared/CONTRIBUTING.md
@@ -4,7 +4,7 @@ wanted][help-wanted] issues for our other contributors.
 - `good first issue` has extra information to help you make your first contribution.
 - `help wanted` are issues suitable for someone who isn't a core maintainer.
 
-Maintainers will do their best regularly make new issues for you to solve and
+Maintainers will do their best to regularly make new issues for you to solve and
 then help out as you work on them. 💖
 
 # Philosophy
@@ -15,12 +15,11 @@ PRs are most welcome!
   the problem or motivation for the change you are proposing. When the solution
   isn't straightforward, for example "Implement missing command X", then also
   outline your proposed solution. Your PR will go smoother if the solution is
-  agreed upon before you've spent a lot of time implementing it.
+  agreed upon before you spend a lot of time implementing it.
   - It's OK to submit a PR directly for problems such as misspellings or other
     things where the motivation/problem is unambiguous.
 - If you aren't sure about your solution yet, put WIP in the title or open as a
-  draft PR so that people know to be nice and wait for you to finish before
-  commenting.
+  draft PR so that people wait for you to finish before reviewing.
 - Try to keep your PRs to a single task. Please don't tackle multiple things in
   a single PR if possible. Otherwise, grouping related changes into commits will
   help us out a bunch when reviewing!

--- a/docs/shared/CONTRIBUTING.md
+++ b/docs/shared/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+We have [good first issues][good-first-issue] for new contributors and [help
+wanted][help-wanted] issues for our other contributors.
+
+- `good first issue` has extra information to help you make your first contribution.
+- `help wanted` are issues suitable for someone who isn't a core maintainer.
+
+Maintainers will do their best regularly make new issues for you to solve and
+then help out as you work on them. 💖
+
+# Philosophy
+
+PRs are most welcome!
+
+- If there isn't an issue for your PR, please make an issue first and explain
+  the problem or motivation for the change you are proposing. When the solution
+  isn't straightforward, for example "Implement missing command X", then also
+  outline your proposed solution. Your PR will go smoother if the solution is
+  agreed upon before you've spent a lot of time implementing it.
+  - It's OK to submit a PR directly for problems such as misspellings or other
+    things where the motivation/problem is unambiguous.
+- If you aren't sure about your solution yet, put WIP in the title or open as a
+  draft PR so that people know to be nice and wait for you to finish before
+  commenting.
+- Try to keep your PRs to a single task. Please don't tackle multiple things in
+  a single PR if possible. Otherwise, grouping related changes into commits will
+  help us out a bunch when reviewing!
+- We encourage "follow-on PRs". If the core of your changes are good, and it
+  won't hurt to do more of the changes later, we like to merge early, and keep
+  working on it in another PR so that others can build on top of your work.
+
+When you're ready to get started, we recommend the following workflow:
+
+```
+$ make build test lint
+```
+
+[good-first-issue]: https://github.com/search?q=org%3Acnabio++label%3A%22good+first+issue%22+state%3Aopen&type=Issues
+[help-wanted]: https://github.com/search?q=org%3Acnabio++label%3A%22help+wanted%22+state%3Aopen&type=Issues
+
+# Cutting a Release
+
+When you are asked to cut a new release, here is the process:
+
+1. Figure out the correct version number, we follow [semver](semver.org):
+    * Bump the major segment if there are any breaking changes.
+    * Bump the minor segment if there are new features only.
+    * Bump the patch segment if there are bug fixes only.
+    * Bump the build segment (version-prerelease.BUILD) if you only
+      fixed something in the build, but the final binaries are the same.
+
+1. Ensure that the master CI build is passing, then make the tag and push it.
+
+   ```
+   git checkout master
+   git pull
+   git tag VERSION -a -m ""
+   git push --tags
+   ```

--- a/docs/shared/README.md
+++ b/docs/shared/README.md
@@ -1,0 +1,3 @@
+Documents in this directory are shared between multiple cnabio repositories.
+They are intended to be the official definition and linked to from the other
+repositories.

--- a/docs/shared/governance.md
+++ b/docs/shared/governance.md
@@ -1,0 +1,14 @@
+# Governance
+
+## Project Maintainers
+[Project maintainers](CODEOWNERS) are responsible for activities around maintaining and updating Duffle, the reference implementation for the [CNAB spec](https://github.com/deislabs/cnab-spec). Final decisions on the project reside with the project maintainers.
+
+Maintainers MUST remain active. If they are unresponsive for >3 months, they will be automatically removed unless a [super-majority](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote) of the other project maintainers agrees to extend the period to be greater than 3 months.
+
+New maintainers can be added to the project by a [super-majority](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote) vote of the existing maintainers.
+
+A maintainer may step down by submitting an [issue](https://github.com/cnabio/duffle/issues/new) stating their intent.
+
+## Code of Conduct
+This project has adopted the [Microsoft Open Source Code of conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/docs/shared/governance.md
+++ b/docs/shared/governance.md
@@ -1,13 +1,13 @@
 # Governance
 
 ## Project Maintainers
-[Project maintainers](CODEOWNERS) are responsible for activities around maintaining and updating Duffle, the reference implementation for the [CNAB spec](https://github.com/deislabs/cnab-spec). Final decisions on the project reside with the project maintainers.
+Project maintainers are defined in the CODEOWNERS file of the respective repositories and are responsible for activities around maintaining the project. Final decisions on the project reside with the project maintainers.
 
 Maintainers MUST remain active. If they are unresponsive for >3 months, they will be automatically removed unless a [super-majority](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote) of the other project maintainers agrees to extend the period to be greater than 3 months.
 
 New maintainers can be added to the project by a [super-majority](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote) vote of the existing maintainers.
 
-A maintainer may step down by submitting an [issue](https://github.com/cnabio/duffle/issues/new) stating their intent.
+A maintainer may step down by submitting an issue stating their intent.
 
 ## Code of Conduct
 This project has adopted the [Microsoft Open Source Code of conduct](https://opensource.microsoft.com/codeofconduct/).


### PR DESCRIPTION
Add common documents that can be linked to from other cnabio repositories and shared, instead of copy/pasting. This will allow us to maintain them in a single location without having drift between the repositories.

- Contributing
- Governance

This preserves the governance doc as-is. In a separate PR, I will suggest changes to match our current practices.